### PR TITLE
add swf to default filePattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When our deployment plugin is ready to deploy, it retrieves the old manifest (fr
 
 Files matching this pattern will be included in the manifest.
 
-_Default:_ `"**/*.{js,css,png,gif,jpg,map,xml,txt,svg,eot,ttf,woff,woff2}"`
+_Default:_ `"**/*.{js,css,png,gif,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}"`
 
 ### manifestPath
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,eot,ttf,woff,woff2}',
+        filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
         manifestPath: 'manifest.txt',
         distDir: function(context) {
           return context.distDir;

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -112,7 +112,7 @@ describe('manifest plugin', function() {
         project: { name: function() { return 'test-project'; } },
         config: {
           manifest: {
-            filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,eot,ttf,woff,woff2}',
+            filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
             manifestPath: 'manifest.txt',
             distDir: function(context){ return context.distDir; },
             distFiles: function(context){ return context.distFiles; }


### PR DESCRIPTION
swf files are necessary for any app using something like ZeroClipboard. Seems like a common enough need to be included by default. [Matching PR for ember-cli-deploy-gzip](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip/pull/7).