### PR TITLE
Update minimatch to ^3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.1",
-    "minimatch": "^2.0.8",
+    "minimatch": "^3.0.3",
     "redis": "^0.12.1",
     "rsvp": "^3.0.18"
   },


### PR DESCRIPTION
## What Changed & Why
minimatch dependency updated to avoid security risk.

Was getting a warning to update to this version to avoid a possibility of a DDOS attack.

`warning ember-cli-deploy-manifest > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`

