### PR TITLE
add ignoreFilePattern config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _Default:_ `"**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2
 
 ### ignoreFilePattern
 
-Files matching this pattern will _not_ be gzipped even if they match filePattern.
+Files matching this pattern will _not_ be included in the manifest even if they match filePattern.
 
 _Default:_ `null`
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Files matching this pattern will be included in the manifest.
 
 _Default:_ `"**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}"`
 
+### ignoreFilePattern
+
+Files matching this pattern will _not_ be gzipped even if they match filePattern.
+
+_Default:_ `null`
+
 ### manifestPath
 
 The relative path that the manifest is written to.

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
       name: options.name,
       defaultConfig: {
         filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
+        fileIgnorePattern: null,
         manifestPath: 'manifest.txt',
         distDir: function(context) {
           return context.distDir;
@@ -26,14 +27,20 @@ module.exports = {
       },
 
       willUpload: function(/* context */) {
-        var filePattern  = this.readConfig('filePattern');
-        var distDir      = this.readConfig('distDir');
-        var distFiles    = this.readConfig('distFiles');
-        var manifestPath = this.readConfig('manifestPath');
+        var filePattern       = this.readConfig('filePattern');
+        var distDir           = this.readConfig('distDir');
+        var distFiles         = this.readConfig('distFiles');
+        var manifestPath      = this.readConfig('manifestPath');
+        var fileIgnorePattern = this.readConfig('fileIgnorePattern');
 
         this.log('generating manifest at `' + manifestPath + '`', { verbose: true });
         try {
           var filesToInclude = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
+          if (fileIgnorePattern != null) {
+            filesToInclude = filesToInclude.filter(function(path) {
+              return !minimatch(path, fileIgnorePattern, { matchBase: true });
+            });
+          }
           filesToInclude.sort();
           var outputPath = path.join(distDir, manifestPath);
           fs.writeFileSync(outputPath, filesToInclude.join('\n'));


### PR DESCRIPTION
Allow specific files to be omitted from the manifest file.

## What Changed & Why
My use case is I need to deploy certain files to s3 on every deploy.  The files in question are not fingerprinted, but should always be deployed.   I can achieve this by not having the file present in the manifest.  Adding `ignoreFilePattern` would allow me to configure my deploy.js to ignore my always needed to deploy files.


## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy-manifest/issues/18

## PR Checklist
- [x] Add tests
- [x] Add documentation
~~[ ] Prefix documentation-only commits with [DOC]~~
