### PR TITLE
[DOC] Add more details to config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ When our deployment plugin is ready to deploy, it retrieves the old manifest (fr
 * `willUpload`
 
 ## Configuration Options
+In `config/environment.js` under `ENV['manifest']`
 
 ### filePattern
 


### PR DESCRIPTION
I always come to this repo and have to dive into `test/index-test.js` to find how to configure it, thought I might add it to the readme to make it a faster lookup.

## What Changed & Why
Readme now contains the name of the config key for this repo
