### PR TITLE
[DOC] Specify config file location and format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ When our deployment plugin is ready to deploy, it retrieves the old manifest (fr
 
 ## Configuration Options
 
+Place the following configuration options into `config/deploy.js`, such as:
+```
+ENV.manifest = {
+  fileIgnorePattern: 'robots.txt'
+}
+```
+
 ### filePattern
 
 Files matching this pattern will be included in the manifest.


### PR DESCRIPTION
## What Changed & Why
While investigating why my `robots.txt` file was not being updated in S3 upon deploy I figured I could simply exclude the file from the manifest. I initially tried to add `fileIgnorePattern` into the `ENV.s3` config, until I realized it was supposed to be in `ENV.manifest`. My guess is that I'm not the only one confused by this, so I thought the docs could be a bit more explicit.

## Related issues
None

## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]